### PR TITLE
Add an +MMTk description flag

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -14394,6 +14394,9 @@ Init_GC(void)
 #undef rb_intern
     VALUE rb_mObjSpace;
     VALUE rb_mProfiler;
+#ifdef USE_THIRD_PARTY_HEAP
+    VALUE rb_mMMTk;
+#endif
     VALUE gc_constants;
 
     rb_mGC = rb_define_module("GC");
@@ -14483,6 +14486,10 @@ Init_GC(void)
 #if GC_DEBUG_STRESS_TO_CLASS
     rb_define_singleton_method(rb_mGC, "add_stress_to_class", rb_gcdebug_add_stress_to_class, -1);
     rb_define_singleton_method(rb_mGC, "remove_stress_to_class", rb_gcdebug_remove_stress_to_class, -1);
+#endif
+
+#ifdef USE_THIRD_PARTY_HEAP
+    rb_mMMTk = rb_define_module_under(rb_mGC, "MMTk");
 #endif
 
     {

--- a/template/fake.rb.in
+++ b/template/fake.rb.in
@@ -17,8 +17,8 @@ if inc = arg['i']
     scan(/rb_define_global_const\("(RUBY_\w+)",[^;]*?\bMK(?:INT|STR)\(([^()]*)\)/m) do |n, v|
     version[n] = src.value(v)
   end
-  arg['RUBY_DESCRIPTION_WITH_MJIT'] = src.value('description_with_mjit')
-  arg['RUBY_DESCRIPTION_WITH_YJIT'] = src.value('description_with_yjit')
+  arg['RUBY_DESCRIPTION_PRE'] = src.value('description_pre')
+  arg['RUBY_DESCRIPTION_POST'] = src.value('description_post')
 end
 %>baseruby="<%=arg['BASERUBY']%>"
 _\
@@ -35,15 +35,15 @@ class Object
   CROSS_COMPILING = RUBY_PLATFORM
   constants.grep(/^RUBY_/) {|n| remove_const n}
 % arg['versions'].each {|n, v|
-  <%=n%> = <%if n=='RUBY_DESCRIPTION' %>case
-    when RubyVM.const_defined?(:MJIT) && RubyVM::MJIT.enabled?
-      <%=arg['RUBY_DESCRIPTION_WITH_MJIT'].inspect%>
-    when RubyVM.const_defined?(:YJIT) && RubyVM::YJIT.enabled?
-      <%=arg['RUBY_DESCRIPTION_WITH_YJIT'].inspect%>
-    else
-      <%=v.inspect%>
-    end<%else%><%=v.inspect%><%end%>
+  <%=n%> = <%=v.inspect%>
 % }
+  options = []
+  if RubyVM.const_defined?(:MJIT) && RubyVM::MJIT.enabled?
+    options << ' +MJIT'
+  elsif RubyVM.const_defined?(:YJIT) && RubyVM::YJIT.enabled?
+    options << ' +YJIT'
+  end
+  RUBY_DESCRIPTION = (<%=arg['RUBY_DESCRIPTION_PRE'].inspect%> + options.join('') + <%=arg['RUBY_DESCRIPTION_POST'].inspect%>).freeze
 end
 builddir = File.dirname(File.expand_path(__FILE__))
 srcdir = "<%=arg['srcdir']%>"

--- a/template/fake.rb.in
+++ b/template/fake.rb.in
@@ -43,6 +43,9 @@ class Object
   elsif RubyVM.const_defined?(:YJIT) && RubyVM::YJIT.enabled?
     options << ' +YJIT'
   end
+  if GC.const_defined?(:MMTk)
+    options << ' +MMTk'
+  end
   RUBY_DESCRIPTION = (<%=arg['RUBY_DESCRIPTION_PRE'].inspect%> + options.join('') + <%=arg['RUBY_DESCRIPTION_POST'].inspect%>).freeze
 end
 builddir = File.dirname(File.expand_path(__FILE__))

--- a/version.c
+++ b/version.c
@@ -48,7 +48,7 @@ const char ruby_copyright[] = RUBY_COPYRIGHT;
 const char ruby_engine[] = "ruby";
 
 // Enough space for any combination of option flags
-static char ruby_dynamic_description_buffer[sizeof(ruby_description) + sizeof("+MJIT +YJIT") - 1];
+static char ruby_dynamic_description_buffer[sizeof(ruby_description) + sizeof("+MJIT +YJIT +MMTk") - 1];
 
 // Might change after initialization
 const char *rb_dynamic_description = ruby_description;
@@ -107,10 +107,15 @@ Init_version(void)
 void
 Init_ruby_description(void)
 {
-    if (snprintf(ruby_dynamic_description_buffer, sizeof(ruby_dynamic_description_buffer), "%s%s%s%s",
+    if (snprintf(ruby_dynamic_description_buffer, sizeof(ruby_dynamic_description_buffer), "%s%s%s%s%s",
             ruby_description_pre,
             MJIT_OPTS_ON ? " +MJIT" : "",
             rb_yjit_enabled_p() ? " +YJIT" : "",
+#ifdef USE_THIRD_PARTY_HEAP
+            " +MMTk",
+#else
+            "",
+#endif
             ruby_description_post) < 0) {
         rb_bug("could not format dynamic description string");
     }

--- a/version.h
+++ b/version.h
@@ -76,12 +76,13 @@
 # define RUBY_RELEASE_DATETIME RUBY_RELEASE_DATE
 #endif
 
-# define RUBY_DESCRIPTION_WITH(opt) \
-    "ruby "RUBY_VERSION		    \
-    RUBY_PATCHLEVEL_STR		    \
-    " ("RUBY_RELEASE_DATETIME	    \
-    RUBY_REVISION_STR")"opt" "	    \
-    "["RUBY_PLATFORM"]"
+# define RUBY_DESCRIPTION_PRE \
+    "ruby "RUBY_VERSION             \
+    RUBY_PATCHLEVEL_STR             \
+    " ("RUBY_RELEASE_DATETIME       \
+    RUBY_REVISION_STR")"
+# define RUBY_DESCRIPTION_POST \
+    " ["RUBY_PLATFORM"]"
 # define RUBY_COPYRIGHT		    \
     "ruby - Copyright (C) "	    \
     RUBY_BIRTH_YEAR_STR"-"   \


### PR DESCRIPTION
The first commit has been tested against `master` in https://github.com/chrisseaton/ruby/pull/1. The second commit is MMTk specific.

I also added a module `MMTk` so we can do `defined?(GC::MMTk)`.

Note that I'm branding as _MMTk_ rather than _third party heap_. I think that's a good idea - third party heap is generic, but I think it might be inconsistent with what you're doing elsewhere.