### PR TITLE
Include some basic info on MMTk on crashes

### DIFF
--- a/vm_dump.c
+++ b/vm_dump.c
@@ -37,6 +37,10 @@
 #include "vm_core.h"
 #include "ractor_core.h"
 
+#ifdef USE_THIRD_PARTY_HEAP
+#include "mmtk.h"
+#endif
+
 #define MAX_POSBUF 128
 
 #define VM_CFP_CNT(ec, cfp) \
@@ -1189,6 +1193,16 @@ rb_vm_bugreport(const void *ctx)
         }
 #endif
     }
+
+#ifdef USE_THIRD_PARTY_HEAP
+    fprintf(stderr, "* MMTk:\n\n");
+    fprintf(stderr, "               mmtk_free_bytes: %zu\n", mmtk_free_bytes());
+    fprintf(stderr, "              mmtk_total_bytes: %zu\n", mmtk_total_bytes());
+    fprintf(stderr, "               mmtk_used_bytes: %zu\n", mmtk_used_bytes());
+    fprintf(stderr, "    mmtk_starting_heap_address: 0x%zx\n", (size_t) mmtk_starting_heap_address());
+    fprintf(stderr, "        mmtk_last_heap_address: 0x%zx\n", (size_t) mmtk_last_heap_address());
+    fprintf(stderr, "\n");
+#endif
 }
 
 void


### PR DESCRIPTION
```
../bug.rb:4: [BUG] Segmentation fault at 0x0000000000000001
ruby 3.2.0dev (2022-07-14T10:55:58Z third-party-heap 2fb0aa6292) +MMTk [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0003 p:---- s:0013 e:000012 CFUNC  :[]
c:0002 p:0030 s:0008 E:0003e8 EVAL   ../bug.rb:4 [FINISH]
c:0001 p:0000 s:0003 E:0019e0 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
../bug.rb:4:in `<main>'
../bug.rb:4:in `[]'

-- Machine register context ------------------------------------------------
 RIP: 0x00007f21c5d878da RBP: 0x0000000000000001 RSP: 0x00007fffa5c4d680
 RAX: 0x0000000000000001 RBX: 0x00007f21c783c058 RCX: 0x00007f21c5d87890
 RDX: 0x00007f21c5d8cc20 RDI: 0x0000000000000000 RSI: 0x00007f21c5d8cc20
  R8: 0x0000000000000001  R9: 0x00000000ffffffff R10: 0x0000000055550083
 R11: 0x00007f21f80d8cc0 R12: 0x00005644d5ca7690 R13: 0x00007f21c793bf90
 R14: 0x00005644d5c9bf80 R15: 0x00005644d5c9bf48 EFL: 0x0000000000010247

-- C level backtrace information -------------------------------------------
build/bin/ruby(rb_vm_bugreport+0x5cf) [0x5644d3147f5f]
build/bin/ruby(rb_bug_for_fatal_signal+0xec) [0x5644d31f378c]
build/bin/ruby(sigsegv+0x4d) [0x5644d309d0dd]
[0x7f21f7f01520]
[0x7f21c5d878da]
build/bin/ruby(vm_call_cfunc_with_frame+0x127) [0x5644d311e6f7]
build/bin/ruby(vm_exec_core+0x114) [0x5644d3139c54]
build/bin/ruby(rb_vm_exec+0x985) [0x5644d312b9c5]
build/bin/ruby(rb_ec_exec_node+0xb1) [0x5644d2f3cda1]
build/bin/ruby(ruby_run_node+0x4d) [0x5644d2f420dd]
build/bin/ruby(main+0x7b) [0x5644d2f3c39b]

-- Other runtime information -----------------------------------------------

* Loaded script: ../bug.rb

* Loaded features:

    0 enumerator.so
    1 thread.rb
    2 fiber.so
    3 rational.so
    4 complex.so
    5 ruby2_keywords.rb
    6 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/encdb.so
    7 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/trans/transdb.so
    8 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/rbconfig.rb
    9 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/compatibility.rb
   10 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/defaults.rb
   11 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/deprecate.rb
   12 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/errors.rb
   13 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/unknown_command_spell_checker.rb
   14 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/exceptions.rb
   15 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/basic_specification.rb
   16 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/stub_specification.rb
   17 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/platform.rb
   18 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/util/list.rb
   19 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/version.rb
   20 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/requirement.rb
   21 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/specification.rb
   22 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/util.rb
   23 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/dependency.rb
   24 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/core_ext/kernel_gem.rb
   25 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/monitor.so
   26 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/monitor.rb
   27 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/core_ext/kernel_require.rb
   28 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/core_ext/kernel_warn.rb
   29 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems.rb
   30 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/rubygems/path_support.rb
   31 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/error_highlight/version.rb
   32 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/error_highlight/base.rb
   33 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/error_highlight/formatter.rb
   34 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/error_highlight/core_ext.rb
   35 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/error_highlight.rb
   36 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/version.rb
   37 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/core_ext/name_error.rb
   38 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/levenshtein.rb
   39 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/jaro_winkler.rb
   40 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/spell_checker.rb
   41 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/spell_checkers/name_error_checkers/class_name_checker.rb
   42 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
   43 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/spell_checkers/name_error_checkers.rb
   44 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/spell_checkers/method_name_checker.rb
   45 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/spell_checkers/key_error_checker.rb
   46 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/spell_checkers/null_checker.rb
   47 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/tree_spell_checker.rb
   48 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/spell_checkers/require_path_checker.rb
   49 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/spell_checkers/pattern_key_name_checker.rb
   50 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean/formatter.rb
   51 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/did_you_mean.rb
   52 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/fiddle.so
   53 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/fiddle/closure.rb
   54 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/fiddle/function.rb
   55 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/fiddle/version.rb
   56 /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/fiddle.rb

* Process memory map:

40000000000-40000010000 rwxp 00000000 00:00 0 
60800000000-61800000000 ---p 00000000 00:00 0 
75913400000-75913800000 rwxp 00000000 00:00 0 
80000000000-80000400000 ---p 00000000 00:00 0 
80001400000-80001800000 rwxp 00000000 00:00 0 
460564400000-460564800000 rwxp 00000000 00:00 0 
476113400000-476113800000 rwxp 00000000 00:00 0 
4c9202000000-4c9a02000000 ---p 00000000 00:00 0 
4de315400000-4de315800000 rwxp 00000000 00:00 0 
4e8a12000000-4e8a1a000000 ---p 00000000 00:00 0 
5644d2f0d000-5644d2f37000 r--p 00000000 08:30 4854736                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/bin/ruby
5644d2f37000-5644d3200000 r-xp 0002a000 08:30 4854736                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/bin/ruby
5644d3200000-5644d3316000 r--p 002f3000 08:30 4854736                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/bin/ruby
5644d3317000-5644d331e000 r--p 00409000 08:30 4854736                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/bin/ruby
5644d331e000-5644d331f000 rw-p 00410000 08:30 4854736                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/bin/ruby
5644d331f000-5644d3330000 rw-p 00000000 00:00 0 
5644d51f0000-5644d5cb3000 rw-p 00000000 00:00 0                          [heap]
7f21b8000000-7f21b8021000 rw-p 00000000 00:00 0 
7f21b8021000-7f21bc000000 ---p 00000000 00:00 0 
7f21bc000000-7f21bc021000 rw-p 00000000 00:00 0 
7f21bc021000-7f21c0000000 ---p 00000000 00:00 0 
7f21c0000000-7f21c0021000 rw-p 00000000 00:00 0 
7f21c0021000-7f21c4000000 ---p 00000000 00:00 0 
7f21c442e000-7f21c5d6c000 r--s 00000000 08:30 4854736                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/bin/ruby
7f21c5d6c000-7f21c5d6e000 r--p 00000000 08:01 4962157                    /usr/lib/x86_64-linux-gnu/libffi.so.8.1.0
7f21c5d6e000-7f21c5d74000 r-xp 00002000 08:01 4962157                    /usr/lib/x86_64-linux-gnu/libffi.so.8.1.0
7f21c5d74000-7f21c5d75000 r--p 00008000 08:01 4962157                    /usr/lib/x86_64-linux-gnu/libffi.so.8.1.0
7f21c5d75000-7f21c5d76000 ---p 00009000 08:01 4962157                    /usr/lib/x86_64-linux-gnu/libffi.so.8.1.0
7f21c5d76000-7f21c5d77000 r--p 00009000 08:01 4962157                    /usr/lib/x86_64-linux-gnu/libffi.so.8.1.0
7f21c5d77000-7f21c5d78000 rw-p 0000a000 08:01 4962157                    /usr/lib/x86_64-linux-gnu/libffi.so.8.1.0
7f21c5d7e000-7f21c5d82000 r--p 00000000 08:30 4989951                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/fiddle.so
7f21c5d82000-7f21c5d89000 r-xp 00004000 08:30 4989951                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/fiddle.so
7f21c5d89000-7f21c5d8c000 r--p 0000b000 08:30 4989951                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/fiddle.so
7f21c5d8c000-7f21c5d8d000 r--p 0000d000 08:30 4989951                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/fiddle.so
7f21c5d8d000-7f21c5d8e000 rw-p 0000e000 08:30 4989951                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/fiddle.so
7f21c5d8e000-7f21c5d8f000 r--p 00000000 08:30 4989956                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/monitor.so
7f21c5d8f000-7f21c5d90000 r-xp 00001000 08:30 4989956                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/monitor.so
7f21c5d90000-7f21c5d91000 r--p 00002000 08:30 4989956                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/monitor.so
7f21c5d91000-7f21c5d92000 r--p 00002000 08:30 4989956                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/monitor.so
7f21c5d92000-7f21c5d93000 rw-p 00003000 08:30 4989956                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/monitor.so
7f21c5d93000-7f21c5d94000 r--p 00000000 08:30 4989921                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/trans/transdb.so
7f21c5d94000-7f21c5d95000 r-xp 00001000 08:30 4989921                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/trans/transdb.so
7f21c5d95000-7f21c5d96000 r--p 00002000 08:30 4989921                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/trans/transdb.so
7f21c5d96000-7f21c5d97000 r--p 00002000 08:30 4989921                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/trans/transdb.so
7f21c5d97000-7f21c5d98000 rw-p 00003000 08:30 4989921                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/trans/transdb.so
7f21c5d98000-7f21c5d99000 ---p 00000000 00:00 0 
7f21c5d99000-7f21c5e3a000 rw-p 00000000 00:00 0 
7f21c5e3a000-7f21c5e3b000 ---p 00000000 00:00 0 
7f21c5e3b000-7f21c5edc000 rw-p 00000000 00:00 0 
7f21c5edc000-7f21c5edd000 ---p 00000000 00:00 0 
7f21c5edd000-7f21c5f7e000 rw-p 00000000 00:00 0 
7f21c5f7e000-7f21c5f7f000 ---p 00000000 00:00 0 
7f21c5f7f000-7f21c6020000 rw-p 00000000 00:00 0 
7f21c6020000-7f21c6021000 ---p 00000000 00:00 0 
7f21c6021000-7f21c60c2000 rw-p 00000000 00:00 0 
7f21c60c2000-7f21c60c3000 ---p 00000000 00:00 0 
7f21c60c3000-7f21c6164000 rw-p 00000000 00:00 0 
7f21c6164000-7f21c6165000 ---p 00000000 00:00 0 
7f21c6165000-7f21c6206000 rw-p 00000000 00:00 0 
7f21c6206000-7f21c6207000 ---p 00000000 00:00 0 
7f21c6207000-7f21c62a8000 rw-p 00000000 00:00 0 
7f21c62a8000-7f21c62a9000 ---p 00000000 00:00 0 
7f21c62a9000-7f21c634a000 rw-p 00000000 00:00 0 
7f21c634a000-7f21c634b000 ---p 00000000 00:00 0 
7f21c634b000-7f21c63ec000 rw-p 00000000 00:00 0 
7f21c63ec000-7f21c63ed000 ---p 00000000 00:00 0 
7f21c63ed000-7f21c648e000 rw-p 00000000 00:00 0 
7f21c648e000-7f21c648f000 ---p 00000000 00:00 0 
7f21c648f000-7f21c6530000 rw-p 00000000 00:00 0 
7f21c6530000-7f21c6531000 ---p 00000000 00:00 0 
7f21c6531000-7f21c65d2000 rw-p 00000000 00:00 0 
7f21c65d2000-7f21c65d3000 ---p 00000000 00:00 0 
7f21c65d3000-7f21c6674000 rw-p 00000000 00:00 0 
7f21c6674000-7f21c6675000 ---p 00000000 00:00 0 
7f21c6675000-7f21c6716000 rw-p 00000000 00:00 0 
7f21c6716000-7f21c6717000 ---p 00000000 00:00 0 
7f21c6717000-7f21c67b8000 rw-p 00000000 00:00 0 
7f21c67b8000-7f21c67b9000 ---p 00000000 00:00 0 
7f21c67b9000-7f21c685a000 rw-p 00000000 00:00 0 
7f21c685a000-7f21c685b000 ---p 00000000 00:00 0 
7f21c685b000-7f21c68fc000 rw-p 00000000 00:00 0 
7f21c68fc000-7f21c68fd000 ---p 00000000 00:00 0 
7f21c68fd000-7f21c699e000 rw-p 00000000 00:00 0 
7f21c699e000-7f21c699f000 ---p 00000000 00:00 0 
7f21c699f000-7f21c6a40000 rw-p 00000000 00:00 0 
7f21c6a40000-7f21c6a41000 ---p 00000000 00:00 0 
7f21c6a41000-7f21c6ae2000 rw-p 00000000 00:00 0 
7f21c6ae2000-7f21c6ae3000 ---p 00000000 00:00 0 
7f21c6ae3000-7f21c6b84000 rw-p 00000000 00:00 0 
7f21c6b84000-7f21c6b85000 ---p 00000000 00:00 0 
7f21c6b85000-7f21c6c26000 rw-p 00000000 00:00 0 
7f21c6c26000-7f21c6c27000 ---p 00000000 00:00 0 
7f21c6c27000-7f21c6cc8000 rw-p 00000000 00:00 0 
7f21c6cc8000-7f21c6cc9000 ---p 00000000 00:00 0 
7f21c6cc9000-7f21c6d6a000 rw-p 00000000 00:00 0 
7f21c6d6a000-7f21c6d6b000 ---p 00000000 00:00 0 
7f21c6d6b000-7f21c6e0c000 rw-p 00000000 00:00 0 
7f21c6e0c000-7f21c6e0d000 ---p 00000000 00:00 0 
7f21c6e0d000-7f21c6eae000 rw-p 00000000 00:00 0 
7f21c6eae000-7f21c6eaf000 ---p 00000000 00:00 0 
7f21c6eaf000-7f21c6f50000 rw-p 00000000 00:00 0 
7f21c6f50000-7f21c6f51000 ---p 00000000 00:00 0 
7f21c6f51000-7f21c6ff2000 rw-p 00000000 00:00 0 
7f21c6ff2000-7f21c6ff3000 ---p 00000000 00:00 0 
7f21c6ff3000-7f21c7094000 rw-p 00000000 00:00 0 
7f21c7094000-7f21c7095000 ---p 00000000 00:00 0 
7f21c7095000-7f21c7136000 rw-p 00000000 00:00 0 
7f21c7136000-7f21c7137000 ---p 00000000 00:00 0 
7f21c7137000-7f21c7239000 rw-p 00000000 00:00 0 
7f21c7239000-7f21c723a000 ---p 00000000 00:00 0 
7f21c723a000-7f21c743a000 rw-p 00000000 00:00 0 
7f21c743a000-7f21c743b000 ---p 00000000 00:00 0 
7f21c743b000-7f21c763b000 rw-p 00000000 00:00 0 
7f21c763b000-7f21c763c000 ---p 00000000 00:00 0 
7f21c763c000-7f21f793f000 rw-p 00000000 00:00 0 
7f21f793f000-7f21f7ea0000 r--p 00000000 08:01 6146528                    /usr/lib/locale/locale-archive
7f21f7ea0000-7f21f7ea3000 rw-p 00000000 00:00 0 
7f21f7ea3000-7f21f7ea6000 r--p 00000000 08:01 4962162                    /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7f21f7ea6000-7f21f7eb8000 r-xp 00003000 08:01 4962162                    /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7f21f7eb8000-7f21f7ebb000 r--p 00015000 08:01 4962162                    /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7f21f7ebb000-7f21f7ebc000 r--p 00017000 08:01 4962162                    /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7f21f7ebc000-7f21f7ebd000 rw-p 00018000 08:01 4962162                    /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
7f21f7ebd000-7f21f7ebf000 rw-p 00000000 00:00 0 
7f21f7ebf000-7f21f7ee7000 r--p 00000000 08:01 4962137                    /usr/lib/x86_64-linux-gnu/libc.so.6
7f21f7ee7000-7f21f807b000 r-xp 00028000 08:01 4962137                    /usr/lib/x86_64-linux-gnu/libc.so.6
7f21f807b000-7f21f80d3000 r--p 001bc000 08:01 4962137                    /usr/lib/x86_64-linux-gnu/libc.so.6
7f21f80d3000-7f21f80d4000 ---p 00214000 08:01 4962137                    /usr/lib/x86_64-linux-gnu/libc.so.6
7f21f80d4000-7f21f80d8000 r--p 00214000 08:01 4962137                    /usr/lib/x86_64-linux-gnu/libc.so.6
7f21f80d8000-7f21f80da000 rw-p 00218000 08:01 4962137                    /usr/lib/x86_64-linux-gnu/libc.so.6
7f21f80da000-7f21f80e7000 rw-p 00000000 00:00 0 
7f21f80e7000-7f21f80f4000 r--p 00000000 08:01 4962189                    /usr/lib/x86_64-linux-gnu/libm.so.6
7f21f80f4000-7f21f816e000 r-xp 0000d000 08:01 4962189                    /usr/lib/x86_64-linux-gnu/libm.so.6
7f21f816e000-7f21f81c8000 r--p 00087000 08:01 4962189                    /usr/lib/x86_64-linux-gnu/libm.so.6
7f21f81c8000-7f21f81c9000 ---p 000e1000 08:01 4962189                    /usr/lib/x86_64-linux-gnu/libm.so.6
7f21f81c9000-7f21f81ca000 r--p 000e1000 08:01 4962189                    /usr/lib/x86_64-linux-gnu/libm.so.6
7f21f81ca000-7f21f81cb000 rw-p 000e2000 08:01 4962189                    /usr/lib/x86_64-linux-gnu/libm.so.6
7f21f81cb000-7f21f81cd000 r--p 00000000 08:01 4962146                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7f21f81cd000-7f21f81e1000 r-xp 00002000 08:01 4962146                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7f21f81e1000-7f21f81fa000 r--p 00016000 08:01 4962146                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7f21f81fa000-7f21f81fb000 ---p 0002f000 08:01 4962146                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7f21f81fb000-7f21f81fc000 r--p 0002f000 08:01 4962146                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7f21f81fc000-7f21f81fd000 rw-p 00030000 08:01 4962146                    /usr/lib/x86_64-linux-gnu/libcrypt.so.1.1.0
7f21f81fd000-7f21f8205000 rw-p 00000000 00:00 0 
7f21f8205000-7f21f8207000 r--p 00000000 08:01 4962268                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7f21f8207000-7f21f8218000 r-xp 00002000 08:01 4962268                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7f21f8218000-7f21f821e000 r--p 00013000 08:01 4962268                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7f21f821e000-7f21f821f000 ---p 00019000 08:01 4962268                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7f21f821f000-7f21f8220000 r--p 00019000 08:01 4962268                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7f21f8220000-7f21f8221000 rw-p 0001a000 08:01 4962268                    /usr/lib/x86_64-linux-gnu/libz.so.1.2.11
7f21f8222000-7f21f8223000 r--p 00000000 08:30 4989915                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/encdb.so
7f21f8223000-7f21f8224000 r-xp 00001000 08:30 4989915                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/encdb.so
7f21f8224000-7f21f8225000 r--p 00002000 08:30 4989915                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/encdb.so
7f21f8225000-7f21f8226000 r--p 00002000 08:30 4989915                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/encdb.so
7f21f8226000-7f21f8227000 rw-p 00003000 08:30 4989915                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/ruby/3.2.0+1/x86_64-linux/enc/encdb.so
7f21f8227000-7f21f8243000 r--p 00000000 08:30 4854739                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/libmmtk_ruby.so
7f21f8243000-7f21f836a000 r-xp 0001c000 08:30 4854739                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/libmmtk_ruby.so
7f21f836a000-7f21f83ae000 r--p 00143000 08:30 4854739                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/libmmtk_ruby.so
7f21f83ae000-7f21f83be000 r--p 00186000 08:30 4854739                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/libmmtk_ruby.so
7f21f83be000-7f21f83bf000 rw-p 00196000 08:30 4854739                    /home/spin/src/github.com/chrisseaton/ruby-mmtk-builder/ruby/build/lib/libmmtk_ruby.so
7f21f83bf000-7f21f83c2000 rw-p 00000000 00:00 0 
7f21f83c2000-7f21f83c3000 r--p 00000000 08:01 4962118                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7f21f83c3000-7f21f83eb000 r-xp 00001000 08:01 4962118                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7f21f83eb000-7f21f83f5000 r--p 00029000 08:01 4962118                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7f21f83f5000-7f21f83f7000 r--p 00032000 08:01 4962118                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7f21f83f7000-7f21f83f9000 rw-p 00034000 08:01 4962118                    /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
7fffa5452000-7fffa5c51000 rw-p 00000000 00:00 0                          [stack]
7fffa5d36000-7fffa5d3a000 r--p 00000000 00:00 0                          [vvar]
7fffa5d3a000-7fffa5d3c000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]


* MMTk:

               mmtk_free_bytes: 108066533376
              mmtk_total_bytes: 108071108608
               mmtk_used_bytes: 4575232
    mmtk_starting_heap_address: 0x20000000000
        mmtk_last_heap_address: 0x200000000000
```