### PR TITLE
Add a method to query MMTk plan name.

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -14486,6 +14486,15 @@ rb_gcdebug_remove_stress_to_class(int argc, VALUE *argv, VALUE self)
 
 #include "gc.rbinc"
 
+#ifdef USE_THIRD_PARTY_HEAP
+VALUE
+rb_mmtk_plan_name(VALUE _)
+{
+    const char* plan_name = mmtk_plan_name();
+    return rb_str_new(plan_name, strlen(plan_name));
+}
+#endif
+
 void
 Init_GC(void)
 {
@@ -14588,6 +14597,7 @@ Init_GC(void)
 
 #ifdef USE_THIRD_PARTY_HEAP
     rb_mMMTk = rb_define_module_under(rb_mGC, "MMTk");
+    rb_define_singleton_method(rb_mMMTk, "plan_name", rb_mmtk_plan_name, 0);
 #endif
 
     {

--- a/mmtk.h
+++ b/mmtk.h
@@ -80,6 +80,7 @@ extern void mmtk_flush_mark_buffer(MMTk_VMMutatorThread tls);
 extern bool mmtk_will_never_move(void* object);
 extern bool mmtk_process(char* name, char* value);
 extern void mmtk_handle_user_collection_request(MMTk_VMMutatorThread tls);
+extern const char* mmtk_plan_name();
 
 /**
  * VM Accounting


### PR DESCRIPTION
This PR allows querying the plan name using `GC::MMTk::plan_name`.
```ruby
puts GC::MMTk::plan_name
```