### PR TITLE
Fix compilation warnings

### DIFF
--- a/gc.h
+++ b/gc.h
@@ -122,7 +122,7 @@ struct rb_thread_struct;
 #define MMTK_DEFAULT_PLAN "MarkSweep"
 void rb_gc_init_collection();
 void rb_mmtk_pre_process_opts(int argc, char **argv);
-void rb_mmtk_post_process_opts(char *arg);
+void rb_mmtk_post_process_opts(const char *arg);
 void rb_mmtk_post_process_opts_finish(void);
 #endif // USE_THIRD_PARTY_HEAP
 

--- a/mmtk.h
+++ b/mmtk.h
@@ -63,7 +63,7 @@ extern void* mmtk_alloc_slow(MMTk_Mutator mutator, size_t size,
     size_t align, ssize_t offset, int semantics);
 
 extern void mmtk_post_alloc(MMTk_Mutator mutator, void* refer,
-    int bytes, int semantics);
+    size_t bytes, int semantics);
 
 /**
  * Tracing

--- a/string.c
+++ b/string.c
@@ -462,7 +462,7 @@ fstr_update_callback(st_data_t *key, st_data_t *value, st_data_t data, int exist
 	RBASIC(str)->flags |= RSTRING_FSTR;
 
 #ifdef USE_THIRD_PARTY_HEAP
-        mmtk_register_finalizable(str);
+        mmtk_register_finalizable((void *)str);
 #endif // USE_THIRD_PARTY_HEAP
 
 	*key = *value = arg->fstr = str;


### PR DESCRIPTION
Currently the `third-party-heap` branch does not compile with `clang` because clang uses `-Werror=shorten-64-to-32` whereas GCC does not.

This PR fixes compilation with clang, and addresses most warnings when using either GCC or clang, when compiled with MMTk enabled and not.

**Note:** 
There is still one warning present when using the GCC 12 included in Fedora 36. I have not addressed this as part of this PR as it's present on the upstream master branch.

Outstanding warning is as follows:

```
compiling gc.c
gc.c: In function ‘objspace_xfree’:
gc.c:12278:33: warning: pointer ‘ptr’ used after ‘free’ [-Wuse-after-free]
12278 |          malloc_increase_done = objspace_malloc_increase_body(__VA_ARGS__))
      |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
gc.c:12591:5: note: in expansion of macro ‘objspace_malloc_increase’
12591 |     objspace_malloc_increase(objspace, ptr, 0, old_size, MEMOP_TYPE_FREE) {
      |     ^~~~~~~~~~~~~~~~~~~~~~~~
gc.c:12592:9: note: call to ‘free’ here
12592 |         free(ptr);
      |         ^~~~~~~~~
```