### PR TITLE
Use new API for setting MMTk options

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -1877,20 +1877,17 @@ rb_objspace_alloc(void)
 
 #if USE_MMTK
     if (rb_mmtk_enabled_p()) {
-        if (!mmtk_env_plan && setenv("MMTK_PLAN", mmtk_chosen_plan, 0) != 0) {
-            fputs("[FATAL] could not set MMTK_PLAN\n", stderr);
-            exit(EXIT_FAILURE);
-        }
+        MMTk_Builder mmtk_builder = mmtk_builder_default();
+
+        mmtk_builder_set_plan(mmtk_builder, mmtk_chosen_plan);
 
         // Note: the limit is currently broken for NoGC, but we still attempt to
         // initialise it properly regardless.
         // See https://github.com/mmtk/mmtk-core/issues/214
-        mmtk_init_binding(rb_mmtk_heap_limit(), &ruby_upcalls);
+        size_t heap_size = rb_mmtk_heap_limit();
+        mmtk_builder_set_heap_size(mmtk_builder, heap_size);
 
-        if (!mmtk_env_plan && unsetenv("MMTK_PLAN") != 0) {
-            fputs("[FATAL] could not unset MMTK_PLAN\n", stderr);
-            exit(EXIT_FAILURE);
-        }
+        mmtk_init_binding(mmtk_builder, &ruby_upcalls);
     }
 #endif
 

--- a/mmtk.h
+++ b/mmtk.h
@@ -13,6 +13,7 @@ extern "C" {
 #define MMTK_MIN_OBJ_ALIGN 8
 #define MMTK_OBJREF_OFFSET 8
 
+typedef void* MMTk_Builder;
 typedef void* MMTk_Mutator;
 typedef void* MMTk_TraceLocal;
 
@@ -39,9 +40,20 @@ typedef struct {
 } RubyUpcalls;
 
 /**
+ * MMTK builder and options
+ */
+MMTk_Builder mmtk_builder_default();
+
+void mmtk_builder_set_heap_size(MMTk_Builder builder, uintptr_t heap_size);
+
+void mmtk_builder_set_plan(MMTk_Builder builder, const char *plan_name);
+
+void mmtk_init_binding(MMTk_Builder builder, const RubyUpcalls *upcalls);
+
+/**
  * Initialization
  */
-extern void mmtk_init_binding(size_t heap_size, RubyUpcalls *ruby_upcalls);
+extern void mmtk_init_binding(MMTk_Builder builder, const RubyUpcalls *upcalls);
 extern void mmtk_initialize_collection(void *tls);
 extern void mmtk_enable_collection();
 


### PR DESCRIPTION
This PR has an associated PR in the mmtk-ruby repo: https://github.com/mmtk/mmtk-ruby/pull/5

We expose options as API functions so that we can set the options in a proper way.

~~TODO: Ensure that MMTK environment variables are still effective.  Currently, we give MMTk a whole Options struct with default values set, so environment variables should override default values (but not values set via command lines) in order to be effective.  However, the common sense is usually that command line options should override environment variables.~~

About environment variable options: The status quo is, when an `Options` struct is created, it is populated in the following order:
1.  default values defined in `mmtk-core/src/util/options.rs` 
2.  environment variables (`MMTK_*`)

Options from other sources (such as command line) are applied later.  Options applied later **overwrites** their existing values.  So environment variables are still effective.  However, this behaviour makes it difficult for Ruby to set Ruby-specific default values.  See https://github.com/mmtk/mmtk-core/issues/636