### PR TITLE
Reduce the diff with upstream

### DIFF
--- a/thread_sync.c
+++ b/thread_sync.c
@@ -1277,7 +1277,13 @@ rb_szqueue_push(int argc, VALUE *argv, VALUE self)
             ccan_list_add_tail(pushq, &queue_waiter.w.node);
             sq->num_waiting_push++;
 
-            rb_ensure(queue_sleep, self, szqueue_sleep_done, (VALUE)&queue_waiter);
+            struct queue_sleep_arg queue_sleep_arg = {
+                .self = self,
+                .timeout = Qnil,
+                .end = 0
+            };
+
+            rb_ensure(queue_sleep, (VALUE)&queue_sleep_arg, szqueue_sleep_done, (VALUE)&queue_waiter);
         }
     }
 


### PR DESCRIPTION
This reduces the diff with upstream Ruby to just 2600 lines. In some cases I've 'broken' the indenting, so that blocks of otherwise unmodified code don't show up in the diff and don't cause merge conflicts, but I think it's still very readable.

With this in place we can continue to garden the code we have different from upstream to keep it as nice as possible.