### PR TITLE
Support obj_free

### DIFF
--- a/gc.c
+++ b/gc.c
@@ -15319,12 +15319,6 @@ rb_mmtk_scan_object_ruby_style(void *object)
     gc_mark_children(objspace, obj);
 }
 
-static void
-rb_mmtk_obj_free(void *object) {
-    printf("Called back from Finalization.  Freeing %p\n", object);
-    obj_free(&rb_objspace, (VALUE)object);
-}
-
 RubyUpcalls ruby_upcalls = {
     rb_mmtk_init_gc_worker_thread,
     rb_mmtk_get_gc_thread_tls,
@@ -15338,7 +15332,6 @@ RubyUpcalls ruby_upcalls = {
     rb_mmtk_scan_thread_roots,
     rb_mmtk_scan_thread_root,
     rb_mmtk_scan_object_ruby_style,
-    rb_mmtk_obj_free,
 };
 
 // Use up to 80% of memory for the heap

--- a/mmtk.h
+++ b/mmtk.h
@@ -24,6 +24,17 @@ typedef void* MMTk_VMMutatorThread;
 #define MMTK_GC_THREAD_KIND_CONTROLLER 0
 #define MMTK_GC_THREAD_KIND_WORKER 1
 
+struct ObjectClosure {
+    void* (*c_function)(void* rust_closure, void* worker, void *data);
+    void* rust_closure;
+};
+
+struct RawVecOfObjRef {
+    void **ptr;
+    size_t len;
+    size_t capa;
+};
+
 typedef struct {
     void (*init_gc_worker_thread)(MMTk_VMWorkerThread worker_tls);
     MMTk_VMWorkerThread (*get_gc_thread_tls)(void);
@@ -111,13 +122,10 @@ extern void mmtk_add_phantom_candidate(void* ref);
 extern void mmtk_harness_begin(void *tls);
 extern void mmtk_harness_end(void *tls);
 
-extern void mmtk_register_finalizable(void *reff);
-extern void* mmtk_poll_finalizable(bool include_live);
-
-struct ObjectClosure {
-    void* (*c_function)(void* rust_closure, void* worker, void *data);
-    void* rust_closure;
-};
+extern void mmtk_add_finalizer(void *reff);
+extern void* mmtk_get_finalized_object();
+extern struct RawVecOfObjRef mmtk_get_all_finalizers();
+extern void mmtk_free_raw_vec_of_obj_ref(struct RawVecOfObjRef raw_vec);
 
 #ifdef __cplusplus
 }

--- a/mmtk.h
+++ b/mmtk.h
@@ -48,7 +48,6 @@ typedef struct {
     void (*scan_thread_roots)(void);
     void (*scan_thread_root)(MMTk_VMMutatorThread mutator, MMTk_VMWorkerThread worker);
     void (*scan_object_ruby_style)(void *object);
-    void (*obj_free)(void *object);
 } RubyUpcalls;
 
 /**

--- a/mmtk.h
+++ b/mmtk.h
@@ -37,6 +37,7 @@ typedef struct {
     void (*scan_thread_roots)(void);
     void (*scan_thread_root)(MMTk_VMMutatorThread mutator, MMTk_VMWorkerThread worker);
     void (*scan_object_ruby_style)(void *object);
+    void (*obj_free)(void *object);
 } RubyUpcalls;
 
 /**

--- a/string.c
+++ b/string.c
@@ -475,12 +475,6 @@ fstr_update_callback(st_data_t *key, st_data_t *value, st_data_t data, int exist
         }
         RBASIC(str)->flags |= RSTRING_FSTR;
 
-#if USE_MMTK
-        if (rb_mmtk_enabled_p()) {
-            mmtk_register_finalizable((void *)str);
-        }
-#endif
-
         *key = *value = arg->fstr = str;
         return ST_CONTINUE;
     }


### PR DESCRIPTION
Associated PR: https://github.com/mmtk/mmtk-ruby/pull/8

We add all types that has non-trivial clean-up code in `obj_free` as candidates for finalization.  MMTk-core will put them into a queue when they die.

This PR mainly focuses on recycling off-heap buffers of large arrays and strings.  If those off-heap objects are not recycled in time, it may thrash the whole system before being killed by the operating system.  So currently the invocation of finalizers is invoked by `ruby_xmalloc`.  When allocating too much off-heap objects using `ruby_xmalloc`, it will trigger GC, and execute `obj_free` on ready-to-finalize objects.  This gives us a chance to free the off-heap xmalloc-allocated buffers for dead objects.

Known issues:
-   We still need to give the Ruby VM a chance to call `obj_free` when GC is triggered by regular heap allocations, and we want to avoid calling finalizers on the fast path of allocation.
-   The GC cannot scan objects that already have `obj_free` called on them, because it frees the underlying data structures (usually off-heap C objects of `T_DATA`) which `dmark` attempts to read.  Currently, we change the object type to `T_NONE` after calling `obj_free`, and skip `T_NONE` before calling `gc_mark_children`.  When the feature in mmtk-core is ready (see https://github.com/mmtk/mmtk-core/issues/648), we will invalidate the objects by clearing its "valid-object bit" so that mmtk-core will not attempt to call `Scanning::scan_object` on invalid objects.

