### PR TITLE
Only enable harness use when MMTk is enabled

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -6129,6 +6129,7 @@ error.$(OBJEXT): {$(VPATH)}constant.h
 error.$(OBJEXT): {$(VPATH)}defines.h
 error.$(OBJEXT): {$(VPATH)}encoding.h
 error.$(OBJEXT): {$(VPATH)}error.c
+error.$(OBJEXT): {$(VPATH)}gc.h
 error.$(OBJEXT): {$(VPATH)}id.h
 error.$(OBJEXT): {$(VPATH)}id_table.h
 error.$(OBJEXT): {$(VPATH)}intern.h

--- a/error.c
+++ b/error.c
@@ -28,6 +28,7 @@
 #endif
 
 #include "internal.h"
+#include "gc.h"
 #include "internal/error.h"
 #include "internal/eval.h"
 #include "internal/hash.h"

--- a/gc.c
+++ b/gc.c
@@ -156,8 +156,9 @@ MMTk_RubyUpcalls ruby_upcalls;
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
-#if USE_MMTK
 static bool mmtk_enable = false;
+
+#if USE_MMTK
 static const char *mmtk_env_plan = NULL;
 static const char *mmtk_pre_arg_plan = NULL;
 static const char *mmtk_post_arg_plan = NULL;
@@ -1966,6 +1967,7 @@ rb_objspace_alloc(void)
 
 #if USE_MMTK
     if (rb_mmtk_enabled_p()) {
+        
         MMTk_Builder *mmtk_builder = mmtk_builder_default();
 
         mmtk_builder_set_plan(mmtk_builder, mmtk_chosen_plan);
@@ -15134,6 +15136,9 @@ gc_using_rvargc_p(VALUE mod)
 static VALUE
 rb_mmtk_plan_name(VALUE _)
 {
+    if (!rb_mmtk_enabled_p()) {
+        rb_raise(rb_eRuntimeError, "Debug harness can only be used when MMTk is enabled, re-run with --mmtk.");
+    }
     const char* plan_name = mmtk_plan_name();
     return rb_str_new(plan_name, strlen(plan_name));
 }
@@ -15169,6 +15174,9 @@ rb_mmtk_enabled(VALUE _)
 static VALUE
 rb_mmtk_harness_begin(VALUE _)
 {
+    if (!rb_mmtk_enabled_p()) {
+        rb_raise(rb_eRuntimeError, "Debug harness can only be used when MMTk is enabled, re-run with --mmtk.");
+    }
     mmtk_harness_begin((MMTk_VMMutatorThread)GET_THREAD());
     return Qnil;
 }
@@ -15185,6 +15193,9 @@ rb_mmtk_harness_begin(VALUE _)
 static VALUE
 rb_mmtk_harness_end(VALUE _)
 {
+    if (!rb_mmtk_enabled_p()) {
+        rb_raise(rb_eRuntimeError, "Debug harness can only be used when MMTk is enabled, re-run with --mmtk.");
+    }
     mmtk_harness_end((MMTk_VMMutatorThread)GET_THREAD());
     return Qnil;
 }
@@ -16187,8 +16198,9 @@ void rb_mmtk_post_process_opts_finish(bool feature_enable) {
     }
 }
 
+#endif
+
 bool rb_mmtk_enabled_p(void) {
     return mmtk_enable;
 }
 
-#endif

--- a/gc.h
+++ b/gc.h
@@ -126,8 +126,9 @@ void rb_gc_init_collection(void);
 void rb_mmtk_pre_process_opts(int argc, char **argv);
 void rb_mmtk_post_process_opts(const char *arg);
 void rb_mmtk_post_process_opts_finish(bool feature_enable);
-bool rb_mmtk_enabled_p(void);
 #endif
+
+bool rb_mmtk_enabled_p(void);
 
 RUBY_SYMBOL_EXPORT_BEGIN
 


### PR DESCRIPTION
to avoid attempting to use the Binding before initialisation