### PR TITLE
Fix undeclared function `rb_mmtk_enabled_p` when compiling

### DIFF
--- a/error.c
+++ b/error.c
@@ -1070,7 +1070,7 @@ rb_bug_for_fatal_signal(ruby_sighandler_t default_sighandler, int sig, const voi
     const char *file = NULL;
     int line = 0;
 
-#ifdef USE_MMTK
+#if USE_MMTK
     // When using MMTk, this function may be called from GC worker threads,
     // in which case there will not be a Ruby execution context.
     if (rb_current_execution_context(!rb_mmtk_enabled_p())) {

--- a/gc.c
+++ b/gc.c
@@ -10070,7 +10070,7 @@ rb_gc_prepare_heap(void)
 static int
 gc_is_moveable_obj(rb_objspace_t *objspace, VALUE obj)
 {
-#ifdef USE_MMTK
+#if USE_MMTK
     if (rb_mmtk_enabled_p()) {
         rb_bug("Function %s should not be called when MMTk is enabled.", RUBY_FUNCTION_NAME_STRING);
     }


### PR DESCRIPTION
I noticed that in CI and locally the `mmtk` branch wasn't compiling and failing on the following compilation errors:

```
gc.c:10074:9: error: call to undeclared function 'rb_mmtk_enabled_p'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (rb_mmtk_enabled_p()) {
        ^
```

```
error.c:1076:39: error: call to undeclared function 'rb_mmtk_enabled_p'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (rb_current_execution_context(!rb_mmtk_enabled_p())) {
                                      ^
```

The `internal/mmtk_support.h` header is included fine, but these two lines were using `ifdef USE_MMTK` rather than `if USE_MMTK`. Changing these allows CRuby mmtk branch to get past these compilation errors.

See https://github.com/mmtk/ruby/actions/runs/8416953029/job/23044511739 for an example of these errors.