### PR TITLE
Fix missing type for `rb_debug_rstring_null_ptr`

### DIFF
--- a/string.c
+++ b/string.c
@@ -434,6 +434,7 @@ rb_str_make_embedded(VALUE str)
     TERM_FILL(RSTRING(str)->as.embed.ary + len, TERM_LEN(str));
 }
 
+void
 rb_debug_rstring_null_ptr(const char *func)
 {
     fprintf(stderr, "%s is returning NULL!! "


### PR DESCRIPTION
I don't really understand how this type went missing since it's on the upstream version. Maybe a bad rebase/merge? Either way this fixes the following compilation error.

```
string.c:437:1: warning: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
rb_debug_rstring_null_ptr(const char *func)
^
int
string.c:437:1: error: conflicting types for 'rb_debug_rstring_null_ptr'
./include/ruby/internal/core/rstring.h:364:6: note: previous declaration is here
void rb_debug_rstring_null_ptr(const char *func);
     ^
```

Combined with https://github.com/mmtk/ruby/pull/63, the `mmtk` branch successfully compiles on my machine.