### PR TITLE
Remove unnecessary include

### DIFF
--- a/object.c
+++ b/object.c
@@ -44,10 +44,6 @@
 #include "shape.h"
 #include "yjit.h"
 
-#if USE_MMTK
-#include "internal/mmtk_support.h"
-#endif
-
 /* Flags of RObject
  *
  * 1:    ROBJECT_EMBED


### PR DESCRIPTION
Previously there was code that conditionally changed with MMTK but that code was removed in the last sync with master.

That code was changed upstream in
https://github.com/ruby/ruby/pull/10358. Since there are no `if USE_MMTK` calls in this file, we no longer need to include `internal/mmtk_support.h`.