### PR TITLE
Fix mmtk compilation

### DIFF
--- a/iseq.h
+++ b/iseq.h
@@ -15,8 +15,8 @@
 #include "vm_core.h"
 #include "prism_compile.h"
 
-#if USE_MMTK
 #include "internal/mmtk_macros.h"
+#if USE_MMTK
 #include "internal/mmtk_support.h"
 #endif
 

--- a/mmtk_support.c
+++ b/mmtk_support.c
@@ -632,8 +632,9 @@ rb_mmtk_is_ppp(VALUE obj) {
 }
 
 static bool
-rb_mmtk_is_ppp_wrapper(MMTk_ObjectReference obj) {
-    rb_mmtk_is_ppp((VALUE)obj);
+rb_mmtk_is_ppp_wrapper(MMTk_ObjectReference obj)
+{
+    return rb_mmtk_is_ppp((VALUE)obj);
 }
 
 static void


### PR DESCRIPTION
Included two fixes:

**Include mmtk header outside USE_MMTK**

If this is inside the `USE_MMTK` conditional, then `WHEN_USING_MMTK`
macros isn't defined and building CRuby without mmtk will fail.

**Fix return on rb_mmtk_is_ppp_wrapper**

Fixes a warning that `rb_mmtk_is_ppp_wrapper` was not returning a value
for a non-void function.
