### PR TITLE
Experimental support for heap traversal

### DIFF
--- a/internal/mmtk.h
+++ b/internal/mmtk.h
@@ -253,4 +253,8 @@ bool mmtk_is_object_wb_unprotected(MMTk_ObjectReference object);
 
 void mmtk_object_reference_write_post(MMTk_Mutator *mutator, MMTk_ObjectReference object);
 
+void mmtk_print_all_objects(void);
+
+void mmtk_enumerate_objects(void (*callback)(MMTk_ObjectReference, void*), void *data);
+
 #endif /* MMTK_H */

--- a/internal/mmtk_support.h
+++ b/internal/mmtk_support.h
@@ -114,6 +114,7 @@ VALUE rb_mmtk_plan_name(VALUE _);
 VALUE rb_mmtk_enabled(VALUE _);
 VALUE rb_mmtk_harness_begin(VALUE _);
 VALUE rb_mmtk_harness_end(VALUE _);
+VALUE rb_mmtk_print_all_objects(VALUE _);
 
 // Debugging
 bool rb_mmtk_is_mmtk_worker(void);

--- a/mmtk_support.c
+++ b/mmtk_support.c
@@ -1188,6 +1188,7 @@ rb_mmtk_define_gc_mmtk_module(void)
     rb_define_singleton_method(rb_mMMTk, "enabled?", rb_mmtk_enabled, 0);
     rb_define_singleton_method(rb_mMMTk, "harness_begin", rb_mmtk_harness_begin, 0);
     rb_define_singleton_method(rb_mMMTk, "harness_end", rb_mmtk_harness_end, 0);
+    rb_define_singleton_method(rb_mMMTk, "print_all_objects", rb_mmtk_print_all_objects, 0);
 }
 
 /*
@@ -1300,6 +1301,19 @@ rb_mmtk_harness_end(VALUE _)
         fprintf(stderr, "======== End vanilla GC timing report (mmtk-ruby) ========\n");
     }
 
+    return Qnil;
+}
+
+/*
+ *  call-seq:
+ *      GC::MMTk.print_all_objects
+ *
+ *  Traverse the heap and print the addresses of all objects.
+ */
+VALUE
+rb_mmtk_print_all_objects(VALUE _)
+{
+    mmtk_print_all_objects();
     return Qnil;
 }
 


### PR DESCRIPTION
This showcases the experimental heap traversal support introduced in https://github.com/mmtk/mmtk-core/pull/1174 and https://github.com/mmtk/mmtk-ruby/pull/90

Calling `GC::MMTk.print_all_objects` will simply print all object references in the heap.

This PR also enables `TracePoint`.  The following snippet will be able to print "new line!" before each line.

```rb
tp = TracePoint.new(:line) do
  puts "new line!"
end

tp.enable

puts "hello"
puts "world"
```

Output:
```rb
new line!
hello
new line!
world
```