### PR TITLE
Fix missing strbuf

### DIFF
--- a/string.c
+++ b/string.c
@@ -1671,6 +1671,11 @@ rb_str_tmp_frozen_no_embed_acquire(VALUE orig)
         RSTRING(str)->as.heap.ptr = RSTRING(orig)->as.heap.ptr;
         RBASIC(str)->flags |= RBASIC(orig)->flags & STR_NOFREE;
         RBASIC(orig)->flags &= ~STR_NOFREE;
+#if USE_MMTK
+        if (rb_mmtk_enabled_p()) {
+            rb_mmtk_str_set_strbuf(str, RSTRING_EXT(orig)->strbuf);
+        }
+#endif
         STR_SET_SHARED(orig, str);
     }
 


### PR DESCRIPTION
In CI (and locally) we were seeing a failed assertion for the `test_gem_remote_fetcher` test. After much debugging it was clear that for this test the strbuf was missing on `shared` so when `orig` moved, `shared` didn't follow`. This caused the offset to be very off.

```
Assertion Failed: string.c:1805:str_new_frozen_buffer:ofs >= 0
ruby 3.4.0dev (2024-08-09T19:42:38Z reproduction-for-s.. a5b29b5277) +MMTk(Immix) [arm64-darwin23]
```

With a `GC_ASSERT` we tracked down a missing `rb_mmtk_str_set_strbuf` in `rb_str_tmp_frozen_no_embed_acquire`.

Fixes: mmtk/ruby#85