### PR TITLE
Rewrite conditional String code and add assertions in WB

### DIFF
--- a/gc/default.c
+++ b/gc/default.c
@@ -6913,6 +6913,21 @@ void
 rb_gc_impl_writebarrier(void *objspace_ptr, VALUE a, VALUE b)
 {
 #if USE_MMTK
+    // Define the MMTK_WB_ASSERT_VO macro in the compiler command line to enable the assertions.
+    // Whenever writing an object field using the write barrier, it will assert the source object
+    // and the new value are valid objects.
+#ifdef MMTK_WB_ASSERT_VO
+    if (rb_mmtk_enabled_p()) {
+        if (!rb_mmtk_is_valid_objref(a)) {
+            rb_bug("a is not MMTk object: %p", (void*)a);
+        }
+        if (!SPECIAL_CONST_P(b)) {
+            if (!rb_mmtk_is_valid_objref(b)) {
+                rb_bug("b is not MMTk object: %p", (void*)b);
+            }
+        }
+    }
+#endif
     if (rb_mmtk_enabled_p() && rb_mmtk_use_barrier) {
         mmtk_object_reference_write_post(GET_THREAD()->mutator, (MMTk_ObjectReference)a);
         return;
@@ -6958,6 +6973,14 @@ void
 rb_gc_impl_writebarrier_unprotect(void *objspace_ptr, VALUE obj)
 {
 #if USE_MMTK
+    // Define the MMTK_WB_ASSERT_VO macro in the compiler command line to enable the assertions.
+#ifdef MMTK_WB_ASSERT_VO
+    if (rb_mmtk_enabled_p()) {
+        if (!rb_mmtk_is_valid_objref(obj)) {
+            rb_bug("Attempted to unprotect invalid objref: %p", (void*)obj);
+        }
+    }
+#endif
     if (rb_mmtk_enabled_p()) {
         mmtk_register_wb_unprotected_object((MMTk_ObjectReference)obj);
         return;
@@ -7013,6 +7036,14 @@ void
 rb_gc_impl_writebarrier_remember(void *objspace_ptr, VALUE obj)
 {
 #if USE_MMTK
+    // Define the MMTK_WB_ASSERT_VO macro in the compiler command line to enable the assertions.
+#ifdef MMTK_WB_ASSERT_VO
+    if (rb_mmtk_enabled_p()) {
+        if (!rb_mmtk_is_valid_objref(obj)) {
+            rb_bug("Attempt to remember invalid invalid objref: %p", (void*)obj);
+        }
+    }
+#endif
     if (rb_mmtk_enabled_p() && rb_mmtk_use_barrier) {
         mmtk_object_reference_write_post(GET_THREAD()->mutator, (MMTk_ObjectReference)obj);
         return;

--- a/internal/mmtk_macros.h
+++ b/internal/mmtk_macros.h
@@ -5,13 +5,17 @@
 
 #if USE_MMTK
 #define IF_USE_MMTK(a) a
+#define IF_NOT_USE_MMTK(a)
 #define IF_USE_MMTK2(a, b) a
 #define WHEN_USING_MMTK(a) if (rb_mmtk_enabled_p()) { a }
+#define WHEN_NOT_USING_MMTK(a) if (!rb_mmtk_enabled_p()) { a }
 #define WHEN_USING_MMTK2(a, b) if (rb_mmtk_enabled_p()) { a } else { b }
 #else
 #define IF_USE_MMTK(a)
+#define IF_NOT_USE_MMTK(a) a
 #define IF_USE_MMTK2(a, b) b
 #define WHEN_USING_MMTK(a)
+#define WHEN_NOT_USING_MMTK(a) a
 #define WHEN_USING_MMTK2(a, b) b
 #endif
 

--- a/internal/mmtk_support.h
+++ b/internal/mmtk_support.h
@@ -121,6 +121,8 @@ bool rb_mmtk_is_mmtk_worker(void);
 bool rb_mmtk_is_mutator(void);
 void rb_mmtk_assert_mmtk_worker(void);
 void rb_mmtk_assert_mutator(void);
+bool rb_mmtk_is_valid_objref(VALUE obj);
+
 
 // Vanilla GC timing
 void rb_mmtk_gc_probe(bool enter);

--- a/mmtk_support.c
+++ b/mmtk_support.c
@@ -1353,6 +1353,12 @@ rb_mmtk_panic_if_multiple_ractor(const char *msg)
     }
 }
 
+bool
+rb_mmtk_is_valid_objref(VALUE obj)
+{
+    return obj != 0 && obj % sizeof(VALUE) == 0 && mmtk_is_mmtk_object((MMTk_Address)obj);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Vanilla GC timing
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR makes two changes.

Rewrote `string.c` to use the `WHEN_USING_MMTK`, `WHEN_NOT_USING_MMTK` and `WHEN_USING_MMTK2` macros.  It should make the code that depending on whether MMTk is used easier to read and maintain.

Added the ability to do assertions in write barriers about whether the source and the target objects are valid references to MMTk objects.  This will help catching dangling references as soon as they are written into object fields (if written using write barriers, which should be the common case anyway).  The assertions are enabled using the `MMTK_WB_ASSERT_VO` macro.  Note that tests will fail if we enable it now due to existing bugs.

These changes makes preparation for fixing bugs related to strings, including https://github.com/mmtk/ruby/issues/93